### PR TITLE
Show all scores for admin, hide admin scores from non-admin

### DIFF
--- a/app/helpers/contests/scores_helper.rb
+++ b/app/helpers/contests/scores_helper.rb
@@ -1,2 +1,10 @@
 module Contests::ScoresHelper
+  def scores_to_show
+    if @current_user.is_admin?
+      @scores
+    else
+      # Hide admin scores from non-admin users
+      @scores.select{|s| !s.user.is_admin}
+    end
+  end
 end

--- a/app/views/contests/scores/show.html.erb
+++ b/app/views/contests/scores/show.html.erb
@@ -16,7 +16,7 @@ Please update by pressing your F5 key.
 <% end %>
   </tr>
 
-<% @scores.select{|s| !s.user.is_admin}.each_with_index do |score, index| %>
+<% scores_to_show.each_with_index do |score, index| %>
   <tr>
     <td><%= index + 1 %></td>
     <td><%= score.user.name %></td>


### PR DESCRIPTION
Fixing Issue #70.

Admin users' scores were filtered out, and I guess that is the reason why scoreboard seemed to be breaking.

Discussing this problem with Dr. Sakamoto, we decided as follows
- If current user is admin, show all scores
- if current user is not admin, filter admin users' scores out

Please review and merge.
