### PR TITLE
Fix factory and spec

### DIFF
--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -23,7 +23,7 @@ namespace :populate do
   desc "Populate the database with mock data"
   task :mock => :environment do |t|
     puts "Creating a contest with some problems"
-    FactoryGirl.create(:contest)
+    FactoryGirl.create(:contest, save_problems: true)
     puts "Creating 10 groups"
     FactoryGirl.create_list(:group, 10)
     puts "Creating 100 contestants"

--- a/spec/factories/factory.rb
+++ b/spec/factories/factory.rb
@@ -30,12 +30,17 @@ FactoryGirl.define do
   end
 
   factory :contest, class: Contest do
+    ignore do
+      save_problems false
+    end
+
     name 'WUPC'
     introduction 'Waseda University Programming Contest'
     start_time Time.new(2012, 6, 2, 14, 0, 0)
     end_time Time.new(2013, 6, 2, 16, 0, 0)
-    after(:create) do |c|
-      c.problems.concat(FactoryGirl.create_list(:problem, 5))
+    problems { |c| c.problems = FactoryGirl.create_list(:problem, 5) }
+    after(:create) do |c, evaluator|
+      c.problems.each { |p| p.save } if evaluator.save_problems
     end
   end
 

--- a/spec/models/contest_spec.rb
+++ b/spec/models/contest_spec.rb
@@ -6,7 +6,7 @@ describe Contest do
 
   it 'should have problems' do
     expect(contest.problems).not_to be_nil
-    expect(contest).to have(1).problems
+    expect(contest).to have(5).problems
   end
 
 end


### PR DESCRIPTION
I merged 175_database_scaffolding and the result of specs became failed.
It worked on `rake populate:mock` in previous factory, but it didn't work on specs.
So I fixed and now the factory works on both cases.
